### PR TITLE
module.xml: add candisable: no, canuninstall:no

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -6,6 +6,8 @@
 	<publisher>Sangoma Technologies Corporation</publisher>
 	<license>AGPLv3+</license>
 	<licenselink>http://www.gnu.org/licenses/agpl-3.0.txt</licenselink>
+	<candisable>no</candisable>
+	<canuninstall>no</canuninstall>
 	<category>Admin</category>
 	<description>This module manages background processes for your PBX</description>
 	<changelog>


### PR DESCRIPTION
Disabling or uninstalling pm2 breaks FreePBX (fatal error in fwconsole reload), so that shouldn't be allowed.

Or the fatal error should be considered a bug and fixed elsewhere.

----

I agree with the Sangoma CLA for this commit.